### PR TITLE
feat(gorelease): Fix flaky aws-nuke-v2 releases

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
       - next
-    tags:
-      - "*"
   release:
     types:
       - published


### PR DESCRIPTION
While reviewing the failed release, I noticed that the release was being executed twice. One was triggered automatically when a new tag was pushed (GoReleaser 25) and the other was triggered manually (GoReleaser 26).  I removed the tag trigger from the workflow so only published releases work. 

**GoReleaser 25** [v3.48.2-orm](https://github.com/oreillymedia/aws-nuke-v2/tree/refs/tags/v3.48.2-orm) succeeded: [link](https://github.com/oreillymedia/aws-nuke-v2/actions/runs/13795525533)
	- Triggered via push

- Workflow Trigger 1 (push: tags: "*")
When you create a tag like v3.48.2-orm, GitHub pushes that tag.
This immediately triggers the workflow before the release is officially published.
GoReleaser runs and tries to create a release.

**GoReleaser 26** [v3.48.2-orm](https://github.com/oreillymedia/aws-nuke-v2/releases/tag/v3.48.2-orm) failed : [link](https://github.com/oreillymedia/aws-nuke-v2/actions/runs/13795525551)
	- Triggered via release

- Workflow Trigger 2 (release: published)
When you later publish a release using GitHub’s UI (or an automated process), GitHub fires another event: "release published".
This again triggers the workflow.
GoReleaser sees the same tag and release name and tries to create it again, leading to a failure due to duplication.




